### PR TITLE
Replacing single CR occurencies in compiler output

### DIFF
--- a/src/solidity_flattener
+++ b/src/solidity_flattener
@@ -12,6 +12,7 @@ def flatten_contract(solc_AST, output_dest):
 	contract_source_regex = re.compile(r'ContractDefinition \".+\"(?:\n\s+Gas costs: \d+)?\n +Source: "(.+)"')
 	inheritance_regex = re.compile(r'InheritanceSpecifier(?:\n\s+Gas costs: \d+)?\n\s+Source: "(.+)"')
 	using_for_regex = re.compile(r'\n  UserDefinedTypeName "(.+)"')
+	carriage_return_regex = re.compile(r'\r')
 
 	contracts = contract_regex.findall(solc_AST)
 	contract_sources = {}
@@ -39,7 +40,7 @@ def flatten_contract(solc_AST, output_dest):
 		if not found_contract_source:
 			print("FATAL: '{name}' has no attached contract source. Aborting.".format(name=contract_name), file=sys.stderr)
 			return
-
+		
 		contract_sources[contract_name] = found_contract_source.group(1)
 
 	contracts_with_sources = set(contract_sources.keys())
@@ -69,7 +70,7 @@ def flatten_contract(solc_AST, output_dest):
 				print("\t\t" + unsat_depend + " (requires: {})".format(dependency_graph[unsat_depend]), file=sys.stderr)
 			return
 
-		output_solidity_code += ast.literal_eval('\"' + contract_sources[cname] + '\"') + "\n\n"
+		output_solidity_code += re.sub(carriage_return_regex, '', ast.literal_eval('\"' + contract_sources[cname] + '\"')) + "\n\n"
 		processed_contracts.update([cname])
 		del dependency_graph[cname]
 


### PR DESCRIPTION
env:
* Windows 10
* Python 3.6.3
* Solc 0.4.18+commit.9cf6e910.Windows.msvc

Actual behavior: Produced output contains single `CR` occurrences:
![image](https://user-images.githubusercontent.com/5207748/33491244-b12375ee-d6ca-11e7-9aa2-dc0f731e5f84.png)
Additional `CR`s adding new lines to the code.

Expected behavior:
Produced code does not contain additional line breaks. All line breaks are correct to the current OS.
